### PR TITLE
Support configurable multi-path Firefox profile search

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The search results can be **aggregated by hostname**, so that visiting _twitter.
 
 The **number of results** and the **popularity criteria** can be changed in the extension's settings. The popularity can be determined by last visit date, visit count or [Firefox Frecency](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places/Frecency_algorithm) heuristic.
 
+The extension also allows configuring the **Firefox Profile Location**. Since different OSs and package managers (like Snap or Flatpak) might store Firefox profiles in different places, you can provide a comma-separated list of paths to search for `profiles.ini`. The extension will use the first valid path found.
+
 ## Install
 > https://github.com/rmassidda/ulauncher-firefox-history
 

--- a/history.py
+++ b/history.py
@@ -21,10 +21,6 @@ class FirefoxHistory():
         #   Connection to sqlite3 parameters
         self.firefox_profile_location = None
         self.conn = None
-        #   Default connection
-        self.
-        
-        _connection()
 
     def establish_connection(self):
         if self.conn:

--- a/main.py
+++ b/main.py
@@ -23,13 +23,16 @@ class PreferencesEventListener(EventListener):
         extension.fh.aggregate = event.preferences['aggregate']
         #   Results Order
         extension.fh.order = event.preferences['order']
+        #   Firefox Profile Location
+        extension.fh.firefox_profile_location = event.preferences['firefox_profile_location']
+        extension.fh.establish_connection()
         #   Results Number
         try:
             n = int(event.preferences['limit'])
         except:
             n = 10
         extension.fh.limit = n
-        
+
 class PreferencesUpdateEventListener(EventListener):
     def on_event(self,event,extension):
         #   Results Order
@@ -44,6 +47,9 @@ class PreferencesUpdateEventListener(EventListener):
                 pass
         elif event.id == 'aggregate':
             extension.fh.aggregate = event.new_value
+        elif event.id == 'firefox_profile_location':
+            extension.fh.firefox_profile_location = event.new_value
+            extension.fh.establish_connection()
 
 class SystemExitEventListener(EventListener):
     def on_event(self,event,extension):
@@ -59,7 +65,7 @@ class KeywordQueryEventListener(EventListener):
         #   Search into Firefox History
         results = extension.fh.search(query)
         for link in results:
-            #   Encode 
+            #   Encode
             hostname = link[0]
             #   Split Domain Levels
             dm = hostname.split('.')

--- a/manifest.json
+++ b/manifest.json
@@ -34,14 +34,19 @@
           {"value":"visit","text":"Visit Count"},
           {"value":"recent","text":"Last Visit"}
           ]
-      },  
+      },
       {
         "id": "limit",
         "type": "input",
         "name": "Results number",
         "default_value": "5"
+      },
+      {
+        "id": "firefox_profile_location",
+        "type": "text",
+        "name": "Firefox Profile Location",
+        "default_value": "snap/firefox/common/.mozilla/firefox/, .mozilla/firefox/, .config/mozilla/firefox/"
       }
 
     ]
   }
-  


### PR DESCRIPTION
Replace the hardcoded profile paths with a user-configurable setting that accepts a list of comma-separated locations. This addresses issues finding profiles on different package managers (Snap, Flatpak, native).

Changes details:

- Update manifest.json to include firefox_profile_location with sensible defaults for Snap and standard installations.
- Modify FirefoxHistory.searchPlaces to iterate through the provided paths and select the first valid one containing profiles.ini.
- Introduce ProfilesIniNotFoundError to explicitly handle cases where no profile can be resolved.
- Wire up preference changes in main.py to reload the database connection when the location setting is updated.