### PR TITLE
Add bookmarks filtering option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### [Ulauncher](https://ulauncher.io) extension for quickly accessing already visited websites.
 
 ## Use
-> fh 
+> fh
 
 List the five most popular websites in Firefox history.
 
@@ -16,6 +16,8 @@ List the five most popular websites in Firefox history that matches the query
 The search results can be **aggregated by hostname**, so that visiting _twitter.com/UlauncherApp_ and _twitter.com/github_ generates _twitter.com_ as result.
 
 The **number of results** and the **popularity criteria** can be changed in the extension's settings. The popularity can be determined by last visit date, visit count or [Firefox Frecency](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places/Frecency_algorithm) heuristic.
+
+Search results can be filtered to show **bookmarks only**.
 
 ## Install
 > https://github.com/rmassidda/ulauncher-firefox-history

--- a/history.py
+++ b/history.py
@@ -13,6 +13,8 @@ class FirefoxHistory():
         self.order = None
         #   Results number
         self.limit = None
+        #   Bookmarks only
+        self.bookmarks_only = None
         #   Set history location
         history_location = self.searchPlaces()
         #   Temporary  file
@@ -68,19 +70,24 @@ class FirefoxHistory():
     def search(self,query_str):
         #   Aggregate URLs by hostname
         if self.aggregate == "true":
-            query = 'SELECT hostname(url)'
+            query = 'SELECT hostname(moz_places.url)'
         else:
-            query = 'SELECT DISTINCT url'
-        query += ',title FROM moz_places WHERE'
+            query = 'SELECT DISTINCT moz_places.url'
+        query += ',moz_places.title FROM moz_places'
+
+        if self.bookmarks_only == "true":
+            query += ' JOIN moz_bookmarks ON moz_places.id = moz_bookmarks.fk'
+
+        query += ' WHERE'
         #   Search terms
         terms = query_str.split(' ')
         for term in terms:
-            query += ' ((url LIKE "%%%s%%") OR (title LIKE "%%%s%%")) AND' % (term,term)
+            query += ' ((moz_places.url LIKE "%%%s%%") OR (moz_places.title LIKE "%%%s%%")) AND' % (term,term)
         #   Delete last AND
         query = query[:-4]
 
         if self.aggregate == "true":
-            query += ' GROUP BY hostname(url) ORDER BY '
+            query += ' GROUP BY hostname(moz_places.url) ORDER BY '
             #   Firefox Frecency
             if self.order == 'frecency':
                 query += 'sum(frecency)'
@@ -92,7 +99,7 @@ class FirefoxHistory():
                 query += 'max(last_visit_date)'
             #   Not sorted
             else:
-                query += 'hostname(url)'
+                query += 'hostname(moz_places.url)'
         else:
             query += ' ORDER BY '
             #   Firefox Frecency
@@ -106,7 +113,7 @@ class FirefoxHistory():
                 query += 'last_visit_date'
             #   Not sorted
             else:
-                query += 'url'
+                query += 'moz_places.url'
 
         query += ' DESC LIMIT %d' % self.limit
 

--- a/main.py
+++ b/main.py
@@ -29,7 +29,9 @@ class PreferencesEventListener(EventListener):
         except:
             n = 10
         extension.fh.limit = n
-        
+        #   Bookmarks only
+        extension.fh.bookmarks_only = event.preferences['bookmarks_only']
+
 class PreferencesUpdateEventListener(EventListener):
     def on_event(self,event,extension):
         #   Results Order
@@ -44,6 +46,8 @@ class PreferencesUpdateEventListener(EventListener):
                 pass
         elif event.id == 'aggregate':
             extension.fh.aggregate = event.new_value
+        elif event.id == 'bookmarks_only':
+            extension.fh.bookmarks_only = event.new_value
 
 class SystemExitEventListener(EventListener):
     def on_event(self,event,extension):
@@ -59,7 +63,7 @@ class KeywordQueryEventListener(EventListener):
         #   Search into Firefox History
         results = extension.fh.search(query)
         for link in results:
-            #   Encode 
+            #   Encode
             hostname = link[0]
             #   Split Domain Levels
             dm = hostname.split('.')

--- a/manifest.json
+++ b/manifest.json
@@ -34,14 +34,23 @@
           {"value":"visit","text":"Visit Count"},
           {"value":"recent","text":"Last Visit"}
           ]
-      },  
+      },
       {
         "id": "limit",
         "type": "input",
         "name": "Results number",
         "default_value": "5"
+      },
+      {
+        "id": "bookmarks_only",
+        "type": "select",
+        "name": "Search only in bookmarks",
+        "default_value": "false",
+        "options":[
+          {"value":"true","text":"Yes"},
+          {"value":"false","text":"No"}
+        ]
       }
 
     ]
   }
-  


### PR DESCRIPTION
This commit introduces a new user preference 'bookmarks_only' to allow users to restrict search results to only those URLs that are bookmarked in Firefox.

Changes include:
- Added 'bookmarks_only' select option to manifest.json
- Updated FirefoxHistory class in history.py to support the new flag
- Modified the SQL query construction in search method to join moz_places and moz_bookmarks tables when the option is enabled
- Updated main.py to handle the initialization and updates of the new preference